### PR TITLE
[DEMO] End-to-end testing for GCM Core

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -64,3 +64,8 @@ jobs:
         run: behave -k src/test/cucumber/features
       # End DEMO: Cucumber (behave)
 
+      # DEMO: C# (xunit)
+      - name: Run .NET Tests
+        run: dotnet test src/test/csharp-xunit
+      # End DEMO: C# (xunit)
+

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -69,3 +69,11 @@ jobs:
         run: dotnet test src/test/csharp-xunit
       # End DEMO: C# (xunit)
 
+      # DEMO: RobotFramework
+      - name: Install Python Dependencies
+        run: pip install -r src/test/robot/requirements.txt
+
+      - name: Run RobotFramework Tests
+        run: robot -o NONE -l NONE -r NONE src/test/robot/clone.robot
+      # End DEMO: RobotFramework
+

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -1,0 +1,52 @@
+name: Run End-to-End Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ end-to-end-testing]
+
+jobs:
+  build-install-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.103
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build & Install Windows
+        if: contains(matrix.os, 'windows')
+        shell: sh
+        run: |
+          dotnet build --configuration WindowsRelease &&
+          exepath=$(find ./out/windows/Installer.Windows/bin/Release/net472/gcmcore-win-*.exe) &&
+          start "" "$exepath" /WAIT //SILENT //NORESTART
+
+      - name: Build & Install Linux
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          dotnet build --configuration LinuxRelease
+          debpath=$(find ./out/linux/Packaging.Linux/deb/Release/*.deb)
+          sudo apt install $debpath
+          git-credential-manager-core configure
+
+      - name: Build & Install macOS
+        if: contains(matrix.os, 'macos')
+        run: |
+          dotnet build --configuration MacRelease
+          pkgpath=$(find ./out/osx/Installer.Mac/pkg/Release/*.pkg)
+          sudo installer -pkg $pkgpath -target /
+
+      - name: Verify Install
+        run: git config --get-all credential.helper

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
 
+      # Build & Install
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
@@ -50,3 +51,16 @@ jobs:
 
       - name: Verify Install
         run: git config --get-all credential.helper
+      # End Build & Install
+
+      # DEMO: Cucumber (behave)
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Install Python Dependencies
+        run: pip install -r src/test/cucumber/requirements.txt
+
+      - name: Run Cucumber Tests
+        run: behave -k src/test/cucumber/features
+      # End DEMO: Cucumber (behave)
+

--- a/.gitignore
+++ b/.gitignore
@@ -221,7 +221,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -317,7 +317,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -326,7 +326,7 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/
 
 # macOS Finder files
@@ -344,3 +344,6 @@ out/
 # Signing generated Files
 auth.json
 input.json
+
+# Python virtual environments
+venv/

--- a/src/test/csharp-xunit/Clone.cs
+++ b/src/test/csharp-xunit/Clone.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace GCMCore.Tests
+{
+    public class CloneScenarios
+    {
+        [Fact]
+        public void Clone_Public_GitHub_Repository()
+        {
+            // Test constants
+            const string repo = "https://github.com/microsoft/Git-Credential-Manager-Core.git";
+
+            using (GCMTestContext context = new GCMTestContext())
+            {
+                // Clone repository
+                TestHelper.RunInContext(context,
+                    "git", "-C", context.Workspace,
+                    "clone", repo, "test-repo");
+
+                // Verify repository cloned
+                int status = TestHelper.RunInContext(context,
+                    "git", "-C", Path.Join(context.Workspace, "test-repo"),
+                    "status");
+                Assert.Equal(0, status);
+            }
+        }
+    }
+}

--- a/src/test/csharp-xunit/GCMCore.Tests.csproj
+++ b/src/test/csharp-xunit/GCMCore.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/test/csharp-xunit/GCMTestContext.cs
+++ b/src/test/csharp-xunit/GCMTestContext.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+
+namespace GCMCore.Tests
+{
+    public class GCMTestContext : IDisposable
+    {
+        public string Workspace { get; private set; }
+
+        public GCMTestContext()
+        {
+            Workspace = Guid.NewGuid().ToString();
+            Directory.CreateDirectory(Workspace);
+        }
+
+        public void Dispose()
+        {
+            if (!string.IsNullOrWhiteSpace(Workspace) && Directory.Exists(Workspace))
+            {
+                try
+                {
+                    Directory.Delete(Workspace, true);
+                }
+                catch
+                {
+                    // continue on error (usually unauthorized, on Windows)
+                }
+            }
+        }
+    }
+}

--- a/src/test/csharp-xunit/README.md
+++ b/src/test/csharp-xunit/README.md
@@ -1,0 +1,22 @@
+# C# (xunit)
+xunit was chosen for the purposes of this example, but it's by no means the only test adapter available. Other options include:
+- nunit (used by Scalar functional tests)
+- MSTest
+
+Note: if going with a plain .NET test framework, it should _not_ be included in the standard GCM Core solution - it should exist independent of the code it's testing. However, that separation might not even be possible if we want to test the UIs.
+
+## How to run
+1. In this directory (`git-credential-manager-core/src/test/csharp-xunit`), run `dotnet test`
+
+## Pros/Cons
+### Pros
+- **No extra dependencies**
+- Native C# makes contribution easy for people already contributing the GCM Core
+- Finer granularity of parallel execution control (down to per-test, depending on the test adapater)
+
+### Cons
+- To be easily maintainable, will probably require building out substantial test infrastructure, such as:
+  - Helper functions for executing common Git operations & handling text I/O with GCM Core
+  - A "context" structure for organizing information generated and used throughout the tests
+  - Custom, descriptive assertion error messages (like in Scalar functional tests)
+- Tests will be "monolithic" - long scenarios with multiple assertions, without "step" separation

--- a/src/test/csharp-xunit/TestHelper.cs
+++ b/src/test/csharp-xunit/TestHelper.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace GCMCore.Tests
+{
+    public static class TestHelper
+    {
+        public static int RunInContext(GCMTestContext context, string command,
+            params string[] args)
+        {
+            var psi = new ProcessStartInfo(command, string.Join(' ', args))
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            using (Process cmd = new Process() { StartInfo = psi })
+            {
+                cmd.Start();
+                cmd.WaitForExit();
+                return cmd.ExitCode;
+            }
+        }
+    }
+}

--- a/src/test/cucumber/README.md
+++ b/src/test/cucumber/README.md
@@ -1,0 +1,22 @@
+# Cucumber
+Site: https://cucumber.io/tools/cucumber-open/
+
+## How to run
+1. Install Python 3.5+
+2. In this directory (`git-credential-manager-core/src/test/cucumber`), run `python3 -m venv venv`
+3. To activate the virtual environment, run (on a Mac) `source ./venv/bin/activate`
+4. To install dependencies, run `pip install -r requirements.txt`
+5. To run the tests, run `behave`
+
+## Pros/Cons
+### Pros
+- If step definitions are written flexibly, _extremely_ easy to add new scenarios
+- Available in [lots of languages](https://cucumber.io/docs/installation/)
+  - I went with Python for this example because it was the fastest for me to set up
+- Feature files are nearly identical across languages (only really varying by tag syntax)
+
+### Cons
+- C# Gherkin/Cucumber framework (SpecFlow) isn't formally supported as part of Cucumber (it's a separate project, with its own OSS vs. paid licensing model)
+- Developers are often tempted to write brand new step definitions for a single test, rather than reusing/generalizing what already exists
+- You might end up being super picky about grammar in step definitions (I certainly am)
+- Varying support of parallelization (e.g., SpecFlow can only parallelize between feature files, behave doesn't natively support parallel execution, Cucumber.js seems to only support scenario-level parallelization)

--- a/src/test/cucumber/features/clone.feature
+++ b/src/test/cucumber/features/clone.feature
@@ -1,0 +1,9 @@
+Feature: GCM Core with git clone
+
+  Scenario: Clone a public GitHub repository
+    Given a user with the configuration:
+      | config     | value            |
+      | user.name  | Test User        |
+      | user.email | test@example.com |
+    When the user clones https://github.com/microsoft/Git-Credential-Manager-Core.git
+    Then the repository is cloned

--- a/src/test/cucumber/features/environment.py
+++ b/src/test/cucumber/features/environment.py
@@ -1,0 +1,16 @@
+import os
+import uuid
+import shutil
+from pathlib import Path
+
+TEST_ROOT = os.path.join(Path(__file__).parent.resolve(), "../../../../out/test")
+
+def before_scenario(context, scenario):
+    # Create a test directory
+    workspace = Path(os.path.join(TEST_ROOT, str(uuid.uuid4())[:8]))
+    workspace.mkdir(parents=True, exist_ok=True)
+    context.workspace = workspace
+
+def after_scenario(context, scenario):
+    # Clean up test directory
+    shutil.rmtree(context.workspace, ignore_errors = True)

--- a/src/test/cucumber/features/steps/git.py
+++ b/src/test/cucumber/features/steps/git.py
@@ -1,0 +1,26 @@
+from behave import use_step_matcher, given, when, then
+import os
+import subprocess
+
+use_step_matcher("re")
+
+@given('a user with the configuration')
+def step_impl(context):
+    for row in context.table:
+        subprocess.run([
+            "git",
+            "config",
+            "--file", os.path.join(context.workspace, ".gitconfig"),
+            row["config"], row["value"]])
+
+@when('the user clones (?P<repo>.*)')
+def step_impl(context, repo):
+    subprocess.run([
+        "git", "-C", context.workspace,
+        "clone", repo, "test-repo"])
+
+@then('the repository is cloned')
+def step_impl(context):
+    assert 0 == subprocess.run([
+        "git", "-C", os.path.join(context.workspace, "test-repo"),
+        "status"]).returncode

--- a/src/test/cucumber/requirements.txt
+++ b/src/test/cucumber/requirements.txt
@@ -1,0 +1,4 @@
+behave==1.2.6
+parse==1.19.0
+parse-type==0.5.2
+six==1.16.0

--- a/src/test/robot/README.md
+++ b/src/test/robot/README.md
@@ -1,0 +1,20 @@
+# Robot Framework
+Site: https://robotframework.org/
+
+## How to run
+1. Install Python 3.5+
+2. In this directory (`git-credential-manager-core/src/test/robot`), run `python3 -m venv venv`
+3. To activate the virtual environment, run (on a Mac) `source ./venv/bin/activate`
+4. To install dependencies, run `pip install -r requirements.txt`
+5. To run the tests, run `robot -o NONE -l NONE -r NONE clone.robot`
+
+## Pros/Cons
+### Pros
+- Lots of built-in operations, including running a process and interacting with it
+- Existing plugins/extensions cover even more pre-built functionality
+- Highly customizable (or so the documentation tells me)
+
+### Cons
+- Syntax is frustrating (tab separation required between every argument, syntax errors not obvious when run)
+- Test setup/teardown is limited (e.g., can't seem to assign variables in setup section)
+- Custom extensions are in Python only

--- a/src/test/robot/clone.robot
+++ b/src/test/robot/clone.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Documentation	A test suite for verifying functionality of GCM Core with Git
+Library			OperatingSystem
+Library			Process
+Test Teardown	Run Keyword And Ignore Error	Remove Directory	${workspace} 	recursive = true
+
+*** Test Cases ***
+Clone public GitHub repository
+	${uuid} =					Evaluate		str(uuid.uuid4())[:8]	modules=uuid
+	${workspace} =				Set Variable	${CURDIR}/../../../out/test/${uuid}
+	Create Directory			${workspace}
+	${result} =					Run Process		git	-C	${workspace}	clone	https://github.com/microsoft/Git-Credential-Manager-Core.git	test-repo
+	Should Be Equal As Integers	${result.rc}	0
+	${result} =					Run Process		git	-C	${workspace}/test-repo	status
+	Should Be Equal As Integers	${result.rc}	0

--- a/src/test/robot/requirements.txt
+++ b/src/test/robot/requirements.txt
@@ -1,0 +1,1 @@
+robotframework==4.1


### PR DESCRIPTION
## What's Here?
- new end-to-end testing workflow
  - builds, installs, and runs tests on Mac/Linux/Windows
- three example test frameworks (with READMEs providing high-level pros/cons, links to relevant resources, and how to run them locally)
  - RobotFramework
  - Cucumber (behave)
  - C# (xunit)

## Disclaimers
- Workflow trigger isn't necessarily reflective of what it _should_ be - just what was easiest for rapid development
- The code here is (intentionally?) pretty rough - not great naming on C# classes/namespaces/projects, lots of hardcoding in things that should be constants, etc. 
- For Cucumber, I went with Python because it was the fastest thing for me to write, not because I necessarily think it's the best language to use
- The example test doesn't actually interact with GCM Core at all - it's more to show "I can run git commands from the test and check the results" or otherwise show the capabilities of the framework

## My Thoughts
- I've used various Cucumber frameworks & Xunit/Nunit/MSTest, but RobotFramework was completely new to me (and came out of searching for "end-to-end automation frameworks") - its syntax is finicky, but it requires the least actual code-writing of all of them. This being a software project, though, that likely isn't really a benefit 🤷 
  - Also, in my experience, custom domain-specific languages like this are much harder to use (owing to having less documentation than, for example, C#)
  - TL;DR I probably wouldn't go with RobotFramework unless you like the non-code-yness of it
- Between plain C# tests and Cucumber, I think I'd give the edge to Cucumber in terms of my preference to write for
  - I like being able to separate long scenarios into discrete steps - when the test fails, it clearly tells you which step failed
  - With well-written (i.e., not overly-specific) steps, you can get to a point where new tests require no updates to step definitions - you can just write the plaintext scenarios
  - The one major downside (to me) of Cucumber is that it's an external dependency - probably easier on repo maintenance to avoid those

## What I want from you as a reviewer!
- Let me know your opinions/thoughts on which direction feels right for GCM Core
- If I missed a test framework you'd like me to try, I'll add it!

Tagging because I can't add you as a reviewer here: @mjcheetham